### PR TITLE
fix: missing data directory/permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,11 @@ RUN apk add --no-cache curl
 
 ################################################################
 
+RUN mkdir -p /data && \
+    chown -R node: /data
+
+################################################################
+
 WORKDIR /home/node
 USER node
 


### PR DESCRIPTION
fixes: `error: [SHUTDOWN] Bridge Watcher is shutting down (Received: Error: EACCES: permission denied, mkdir '/data')`

:point_up: this error is thrown when running `node main.js mesh`